### PR TITLE
feat: added plugin to forbid android to set dark theme

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,6 +32,9 @@
       }
     },
     "newArchEnabled": true,
-    "owner": "eonenglish"
+    "owner": "eonenglish",
+    "plugins": [
+      "./plugins/withDisableForcedDarkModeAndroid.js"
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "eon-english-app",
       "version": "1.0.0",
       "dependencies": {
+        "@expo/config-plugins": "^9.0.12",
         "@expo/vector-icons": "14.0.4",
         "@react-native-async-storage/async-storage": "1.23.1",
         "@react-native-picker/picker": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format:fix": "prettier ./src ./App.js --write"
   },
   "dependencies": {
+    "@expo/config-plugins": "^9.0.12",
     "@expo/vector-icons": "14.0.4",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-picker/picker": "2.9.0",

--- a/plugins/withDisableForcedDarkModeAndroid.js
+++ b/plugins/withDisableForcedDarkModeAndroid.js
@@ -1,0 +1,46 @@
+// @link https://gist.github.com/hirbod/d6bb5d0fc946a12ba9e3cf01120c604a
+// disable forced dark mode to prevent weird color changes on
+// certain android devices (Xiaomi MIUI and others enforcing dark mode with view analyzing)
+// create a file like "plugins/withDisableForcedDarkModeAndroid.js". Insert this content and edit your app.config.js/app.json
+
+/*
+"expo": {
+   ...
+   ...
+   ...
+   "plugins": [
+       ...,
+       ...,
+       './plugins/withDisableForcedDarkModeAndroid.js'
+   ]
+*/
+
+const {
+  createRunOncePlugin,
+  withAndroidStyles,
+  AndroidConfig,
+} = require("@expo/config-plugins");
+
+function setForceDarkModeToFalse(styles) {
+  styles = AndroidConfig.Styles.assignStylesValue(styles, {
+    add: true,
+    parent: AndroidConfig.Styles.getAppThemeLightNoActionBarGroup(),
+    name: `android:forceDarkAllowed`,
+    value: "false",
+  });
+
+  return styles;
+}
+
+const withDisableForcedDarkModeAndroid = (config) => {
+  return withAndroidStyles(config, (config) => {
+    config.modResults = setForceDarkModeToFalse(config.modResults);
+    return config;
+  });
+};
+
+module.exports = createRunOncePlugin(
+  withDisableForcedDarkModeAndroid,
+  "disable-forced-dark-mode",
+  "1.0.0",
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1301,7 +1301,7 @@
     node-forge "^1.2.1"
     nullthrows "^1.1.1"
 
-"@expo/config-plugins@~9.0.10":
+"@expo/config-plugins@^9.0.12", "@expo/config-plugins@~9.0.10":
   version "9.0.12"
   resolved "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-9.0.12.tgz"
   integrity sha512-/Ko/NM+GzvJyRkq8PITm8ms0KY5v0wmN1OQFYRMkcJqOi3PjlhndW+G6bHpJI9mkQXBaUnHwAiGLqIC3+MQ5Wg==


### PR DESCRIPTION
## Description
Turned off dark theme enabling by android system

Ticket: [#212](https://github.com/EonEnglish/Eon-English-App/issues/212)